### PR TITLE
Updated How To Tutorials for HXE 2.00 SP01 Release

### DIFF
--- a/tutorials/2016/08/hxe-connect-hxe-using-jdbc/hxe-connect-hxe-using-jdbc.md
+++ b/tutorials/2016/08/hxe-connect-hxe-using-jdbc/hxe-connect-hxe-using-jdbc.md
@@ -7,7 +7,11 @@ tags: [  tutorial>beginner, products>sap-hana, products>sap-hana\,-express-editi
 
 ## Prerequisites  
  - **Proficiency:** Beginner
+<<<<<<< HEAD
  - **Setup:** This tutorial assumes that you have followed the [SAP HANA Client Installation and Update Guide](https://help.sap.com/hana/SAP_HANA_Client_Installation_Update_Guide_en.pdf) to install the HANA client software. You can download the HANA client software from [SAP Store](https://store.sap.com/sap/cpa/ui/resources/store/html/SolutionDetails.html?pid=0000012950)
+=======
+ - **Setup:** This tutorial assumes that you have followed the [How to Install SAP HANA 2.0, express edition Clients](http://www.sap.com/developer/how-tos/2016/12/hxe-ua-howto-installing-clients.html) tutorial to install the HANA, express edition client software.
+>>>>>>> Updated the client download statement in the tutorials that depend on HDB client downloads.
 
 ## Next Steps
  - [View similar How-Tos](http://www.sap.com/developer/tutorials.html) or [View all How-Tos](http://www.sap.com/developer/tutorials.html)

--- a/tutorials/2016/08/hxe-connect-hxe-using-jdbc/hxe-connect-hxe-using-jdbc.md
+++ b/tutorials/2016/08/hxe-connect-hxe-using-jdbc/hxe-connect-hxe-using-jdbc.md
@@ -7,11 +7,8 @@ tags: [  tutorial>beginner, products>sap-hana, products>sap-hana\,-express-editi
 
 ## Prerequisites  
  - **Proficiency:** Beginner
-<<<<<<< HEAD
- - **Setup:** This tutorial assumes that you have followed the [SAP HANA Client Installation and Update Guide](https://help.sap.com/hana/SAP_HANA_Client_Installation_Update_Guide_en.pdf) to install the HANA client software. You can download the HANA client software from [SAP Store](https://store.sap.com/sap/cpa/ui/resources/store/html/SolutionDetails.html?pid=0000012950)
-=======
+
  - **Setup:** This tutorial assumes that you have followed the [How to Install SAP HANA 2.0, express edition Clients](http://www.sap.com/developer/how-tos/2016/12/hxe-ua-howto-installing-clients.html) tutorial to install the HANA, express edition client software.
->>>>>>> Updated the client download statement in the tutorials that depend on HDB client downloads.
 
 ## Next Steps
  - [View similar How-Tos](http://www.sap.com/developer/tutorials.html) or [View all How-Tos](http://www.sap.com/developer/tutorials.html)

--- a/tutorials/2016/08/hxe-dot-net-connection/hxe-dot-net-connection.md
+++ b/tutorials/2016/08/hxe-dot-net-connection/hxe-dot-net-connection.md
@@ -7,11 +7,9 @@ tags: [  tutorial>intermediate, products>sap-hana, products>sap-hana\,-express-e
 
 ## Prerequisites  
 - **Proficiency:** Beginner
-<<<<<<< HEAD
-- **Setup:** This tutorial assumes that you have followed the [SAP HANA Client Installation and Update Guide](https://help.sap.com/hana/SAP_HANA_Client_Installation_Update_Guide_en.pdf) to install the HANA client software. You can download the HANA client software from [SAP Store](https://store.sap.com/sap/cpa/ui/resources/store/html/SolutionDetails.html?pid=0000012950).
-=======
+
 - **Setup:** This tutorial assumes that you have followed the [How to Install SAP HANA 2.0, express edition Clients](http://www.sap.com/developer/how-tos/2016/12/hxe-ua-howto-installing-clients.html) tutorial to install the HANA, express edition client software.
->>>>>>> Updated the client download statement in the tutorials that depend on HDB client downloads.
+
 - **Setup:** You must have Microsoft Visual Studio 2010 or later installed on your computer.
 - **Setup:** You must have Microsoft .NET Framework installed on your computer (Generally .NET     Framework will be installed when you install Microsoft Visual Studio).
 

--- a/tutorials/2016/08/hxe-dot-net-connection/hxe-dot-net-connection.md
+++ b/tutorials/2016/08/hxe-dot-net-connection/hxe-dot-net-connection.md
@@ -7,7 +7,11 @@ tags: [  tutorial>intermediate, products>sap-hana, products>sap-hana\,-express-e
 
 ## Prerequisites  
 - **Proficiency:** Beginner
+<<<<<<< HEAD
 - **Setup:** This tutorial assumes that you have followed the [SAP HANA Client Installation and Update Guide](https://help.sap.com/hana/SAP_HANA_Client_Installation_Update_Guide_en.pdf) to install the HANA client software. You can download the HANA client software from [SAP Store](https://store.sap.com/sap/cpa/ui/resources/store/html/SolutionDetails.html?pid=0000012950).
+=======
+- **Setup:** This tutorial assumes that you have followed the [How to Install SAP HANA 2.0, express edition Clients](http://www.sap.com/developer/how-tos/2016/12/hxe-ua-howto-installing-clients.html) tutorial to install the HANA, express edition client software.
+>>>>>>> Updated the client download statement in the tutorials that depend on HDB client downloads.
 - **Setup:** You must have Microsoft Visual Studio 2010 or later installed on your computer.
 - **Setup:** You must have Microsoft .NET Framework installed on your computer (Generally .NET     Framework will be installed when you install Microsoft Visual Studio).
 

--- a/tutorials/2016/08/hxe-python-connection/hxe-python-connection.md
+++ b/tutorials/2016/08/hxe-python-connection/hxe-python-connection.md
@@ -1,11 +1,11 @@
 ---
 title: How to connect to SAP HANA database server in Python
 description: A How-To that shows how to integrate python with the SAP HANA database server
-primary_tag: products>sap-hana\,-express-edition 
+primary_tag: products>sap-hana\,-express-edition
 tags: [  tutorial>intermediate, products>sap-hana, products>sap-hana\,-express-edition , tutorial>how-to ]
 ---
 ## Prerequisites  
- - **Setup:** This tutorial assumes that you have followed the [SAP HANA Client Installation and Update Guide](https://help.sap.com/hana/SAP_HANA_Client_Installation_Update_Guide_en.pdf) to install the HANA client software. You can download the HANA client software from [SAP Store](https://store.sap.com/sap/cpa/ui/resources/store/html/SolutionDetails.html?pid=0000012950).
+ - **Setup:** This tutorial assumes that you have followed the [How to Install SAP HANA 2.0, express edition Clients](http://www.sap.com/developer/how-tos/2016/12/hxe-ua-howto-installing-clients.html) tutorial to install the HANA, express edition client software.
 
 ## Next Steps
  - This is a standalone How-To on establishing basic connectivity to SAP HANA database server in python. [View similar How-Tos](http://www.sap.com/developer/tutorials.html) or [View all How-Tos](http://www.sap.com/developer/tutorials.html)
@@ -44,7 +44,8 @@ In many python applications, you would need access to a database for storing, re
 
     #Replace with your hostname, unique port for the database you are connecting,
     #UserID and password in that order.
-    connection=dbapi.connect('hana-server', '30015', 'system', 'manager')
+
+    connection=dbapi.connect('hxehost', 39013, 'system', 'MyPassword')
 
     #This statement prints true if the connection is successfully established
     print connection.isconnected()

--- a/tutorials/2017/01/hxe-python-django-polls/hxe-python-django-polls.md
+++ b/tutorials/2017/01/hxe-python-django-polls/hxe-python-django-polls.md
@@ -1,0 +1,107 @@
+---
+title: How to use Django with HANA, express edition
+description: A How-To that shows how to integrate Django with the SAP HANA, express edition by identifying HANA specific changes needed to complete the Django `polls` tutorial.
+tags: [  tutorial>intermediate, products>sap-hana, products>sap-hana\,-express-edition, tutorial>how-to ]
+---
+## Prerequisites  
+ - Proficiency: beginner
+ - Setup: `HANA, express edition` must be running.
+
+## Next Steps
+ - This is a standalone How-To on basic integration of the Django web framework with HANA, express edition. [View similar How-Tos](http://www.sap.com/developer/tutorials.html) or [View all How-Tos](http://www.sap.com/developer/tutorials.html)
+
+
+ __ NOTE: SAP HANA, express edition version 2.0 implications on 'How-Tos' and 'Tutorials' __
+
+ The available HANA, express edition versions (1.0 SP12 and 2.0 SP00) have different default instance numbers. The published Tutorials and How-Tos refer to the default HANA 2.0 SP00 instance numbers. When using the SP12 version please use the old default instance number and port (3`<instance number>`15):
+
+ HANA Express Version  | Default Instance ID | Port
+ :-------------------  | :------------------ | :---------------
+ 1.0 SP12              |  00                 | 30013
+ 2.0 SP00              |  90                 | 39013
+
+## How-To Details
+Most Django based web applications use database back-ends for data persistence. This how-to tutorial will show you how to configure Django and your application to use HANA, express-edition as the backend database. You will learn how to
+- configure Django settings for HANA, express edition
+- run [the Django Project tutorial](https://docs.djangoproject.com/en/1.10/intro/tutorial01/) using HANA, express edition as the database.
+
+*Note: The `PyHDB` connector is an open source pure Python client for HANA. `PyHDB` does not support the full Python DBAPI Specification v2.0, nor does it support the full `SAP HANA SQL Command Network Protocol.`
+
+
+### Time to Complete
+**20 Min**.
+
+---
+
+## Installing Django and Django HANA Modules
+
+1. Install Django by following the [Django installation instructions]( https://docs.djangoproject.com/en/1.10/topics/install/#). Verify the installation by running `django-admin --version` in a shell. The command should return a version string such as `1.10.5`
+
+2. The Django HANA implementation relies on the pyhdb driver, a pure python HANA database driver. Run the pip installer to install pyhdb: `pip install pyhdb`. If successful, this pip install command should indicate a successful installation and the version number (e.g. `Successfully installed pyhdb-0.3.3`).
+
+3. Verify that you can connect to the HXE database by creating a small test script.
+
+    a. Create a file called `test_hxe_conn.py` and add the following python code to it. Modify the value based on your needs, using the hints in the comments. At a minimum, you will need to change the host `ip` address and the password.
+
+  ```
+  import pyhdb
+
+  # Define the connection to the HXE database
+  connection = pyhdb.connect(
+      # replace with the ip address of your HXE Host (This may be a virtual machine)
+      host="10.172.91.122",
+      # 39013 is the systemDB port for HXE on the default instance of 90.
+      # Replace 90 with your instance number as needed (e.g. 30013 for instance 00)
+      port=39013,
+      #Replace user and password with your user and password.
+      user="system",
+      password="mypassword"
+      )
+
+  #Connect to the database and issue a dummy query to verify connectivity
+  cursor = connection.cursor()
+  cursor.execute("SELECT 'Hello Django HANA World' FROM DUMMY")
+  #This should return "Hello Django HANA World"
+  myString = cursor.fetchone()[0]
+  print myString
+  #Close the cursor
+  connection.close()
+  ```
+  b. Run your test script in the python shell: `python test_hxe_conn.py`. If you are able to connect, the following string should be returned: `Hello Django HANA World`. If you are unable to connect, make sure that the connectivity setting--host, user, port and password--are correct for your database.
+
+  c. At this point, you have verified that you can use the `pyhdb` database driver to connect to HANA, express edition. Now you need to verify that Django can communicate with the `pyhdb` driver. To do this, you need to download the `django_hana` module from https://github.com/mathebox/django_hana_pyhdb.
+
+      - Navigate to https://github.com/mathebox/django_hana_pyhdb in a browser.
+      - Select `Clone or download`.
+      - Select `Download ZIP` and download the zip to a downloads or temporary directory of your choice. This will create the file `django_hana_pyhdb-master.zip`.
+      - Unzip the contents of `django_hana_pyhdb-master.zip` under `djhxe`. This will create the folder `djhxe/django_hana_pyhdb-master`.
+      - Navigate to `djhxe/django_hana_pyhdb-master`.
+      - Run  `python setup.py install`. This should write out messages to the console indicating that it is `running install` and should conclude with the line `Installed <path>/lib/site-packages/django_hana-1.1-py2.7.egg`. There should not be any errors reported by the pip installer.
+      - You will also need to install the `six` package, a library for cross version transparency of Python code. To install `six`, run `pip install six`. There should not be any errors reported by the pip installer.
+
+## Following the Django Tutorial
+
+Now that you have verified the installation of Django and verified connectivity from Python to HXE, you can follow [the Django tutorial](https://docs.djangoproject.com/en/1.10/intro/tutorial01/) with the following HANA specific modifications.
+
+1. Note: Be sure to complete this step (Step 1) at the beginning of the [Database Setup section of the Django tutorial](https://docs.djangoproject.com/en/1.10/intro/tutorial02/). You will need to make the following modification to `djhxe/settings.py` that is not included in the tutorial.
+
+    a. Modify the database settings in `djhxe/settings.py` to point to your HANA, express edition database.
+    ```
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django_hana',
+            'NAME': 'djhxe',  # This is db schema name. It will be added if it does not exist.
+            'USER': 'System',
+            'PASSWORD': 'myPassword', # Replace with your password.
+            'HOST': '10.172.91.122',  # Replace with your HXE server IP address
+            'PORT': '39013',
+        }
+    }
+    ```
+    b. Because HANA does not support Timezone, you will also need to change the value of USE_TZ in `djhxe/settings.py` from True to False: `USE_TZ=False`.
+    *Note: As a result of this change, there will be time zone values shown in the online tutorial that do not show in your results.*
+
+
+## Next Steps
+ - [View similar How-Tos](http://www.sap.com/developer/tutorials.html) or [View all How-Tos](http://www.sap.com/developer/tutorials.html)
+ - [Complete the Django tutorials](https://docs.djangoproject.com/en/1.10/intro/tutorial01/)

--- a/tutorials/2017/02/hxe-python-sqlalchemy-users/hxe-python-sqlalchemy-users.md
+++ b/tutorials/2017/02/hxe-python-sqlalchemy-users/hxe-python-sqlalchemy-users.md
@@ -1,0 +1,119 @@
+---
+title: How to use SQLAlchemy with HANA, express edition
+description: A How-To that shows how to integrate SQLAlchemy with the SAP HANA, express edition by identifying HANA specific changes needed to complete the SQLAlchemy `users` tutorial.
+tags: [  tutorial>intermediate, products>sap-hana, products>sap-hana\,-express-edition, tutorial>how-to ]
+---
+## Prerequisites  
+ - Proficiency: beginner
+ - Setup: `HANA, express edition` must be running.
+
+## Next Steps
+ - This is a standalone How-To on basic integration of the SQLAlchemy Obect Relational Mapper (ORM) with HANA, express edition. [View similar How-Tos](http://www.sap.com/developer/tutorials.html) or [View all How-Tos](http://www.sap.com/developer/tutorials.html)
+
+
+ __ NOTE: SAP HANA, express edition version 2.0 implications on 'How-Tos' and 'Tutorials' __
+
+ The available HANA, express edition versions (1.0 SP12 and 2.0 SP00) have different default instance numbers. The published Tutorials and How-Tos refer to the default HANA 2.0 SP00 instance numbers. When using the SP12 version please use the old default instance number and port (3`<instance number>`15):
+
+ HANA Express Version  | Default Instance ID | Port
+ :-------------------  | :------------------ | :---------------
+ 1.0 SP12              |  00                 | 30013
+ 2.0 SP00              |  90                 | 39013
+
+## Experimental Packages
+This tutorial relies on the experimental packages [`pyhdb`](https://github.com/SAP/PyHDB/blob/master/README.rst) and [`sqlalchemy-hana`](https://github.com/SAP/sqlalchemy-hana/blob/master/README.rst).
+`pyhdb` is a pure python database client for HANA.
+`sqlalchemy-hana` is a `SQLAlchemy` dialect for HANA. A `SQLAlchemy` dialect is the system `SQLAlchemy` uses to communicate with a particular database.
+
+## How-To Details
+`SQLAlchemy` is an Object Relational Mapper (ORM) that maps python objects to SQL database management system entities. This how-to tutorial will show you how to:
+- configure `SQLAlchemy` settings for HANA, express edition
+- complete [the SQLAlchemy Project tutorial](http://docs.sqlalchemy.org/en/latest/orm/tutorial.html) using HANA, express edition as the database.
+This tutorial assumes that you are installing `SQLAlchemy` and `SQLAlchemy` HANA packages on your client operating system and not on the HANA, express edition virtual machine itself. If you intend to install `SQLAlchemy` on your HANA, express edition virtual machine, you should review the tutorial ["Installing Python Modules on HANA, express edition"](http://www.sap.com/developer/topics/sap-hana-express.tutorials.html) to prepare the virtual machine for installing Python packages from `pypi`.
+
+
+### Time to Complete
+**20 Min**.
+
+---
+
+## Installing `SQLAlchemy` and `SQLALchemy` HANA Modules
+
+1. Install `sqlalchemy-hana` by following the Install `SQLAlchemy` by following the [SQLAlchemy installation instructions]( https://docs.djangoproject.com/en/1.10/topics/install/#). The `sqlalchemy-hana` installation will also install `SQLAlchemy` if it is not already installed in your environment.
+
+2. The `sql-alchemy-hana` implementation relies on the `pyhdb` driver, a pure python HANA database driver. Run the pip installer to install pyhdb: `pip install pyhdb`. If successful, this pip install command should indicate a successful installation and the version number (e.g. "Successfully installed pyhdb-0.3.3").
+
+3. Verify that you can connect to the HXE database by creating a small test script.
+
+    a. Create a file called `test_hxe_conn.py` and add the following python code to it. Modify the value based on your needs, using the hints in the comments. At a minimum, you will need to change the host `ip` address and the password.
+
+  ```
+  import pyhdb
+
+  # Define the connection to the HXE database
+  connection = pyhdb.connect(
+      # replace with the ip address of your HXE Host (This may be a virtual machine)
+      host="10.172.91.122",
+      # 39013 is the systemDB port for HXE on the default instance of 90.
+      # Replace 90 with your instance number as needed (e.g. 30013 for instance 00)
+      port=39013,
+      #Replace user and password with your user and password.
+      user="system",
+      password="mypassword"
+      )
+
+  #Connect to the database and issue a dummy query to verify connectivity
+  cursor = connection.cursor()
+  cursor.execute("SELECT 'Hello HANA SQLAlchemists' FROM DUMMY")
+  #This should return "Hello HANA SQLAlchemists"
+  myString = cursor.fetchone()[0]
+  print myString
+  #Close the cursor
+  connection.close()
+  ```
+  b. Run your test script in the python shell: `python test_hxe_conn.py`. If you are able to connect, the following string should be returned: `Hello HANA SQLAlchemists`. If you are unable to connect, make sure that the connectivity setting--host, user, port and password--are correct for your database.
+
+
+## Running the Tutorial
+
+After making the changes below, you will be able to follow the [SQLAlchemy tutorial](http://docs.sqlalchemy.org/en/latest/orm/tutorial.html) using HANA Express as the backend database.
+
+1. In the "Connecting" section of the [tutorial](http://docs.sqlalchemy.org/en/latest/orm/tutorial.html) you will need to replace the following code for connecting to `sqlite`:
+
+```
+from sqlalchemy import create_engine
+engine = create_engine('sqlite:///:memory:', echo=True)
+```
+
+with the following to connect to HANA, express edition:
+
+```
+from sqlalchemy import create_engine
+engine = create_engine('hana+pyhdb://{}:{}@{}:{}'.format('system', 'myPassword', '10.125.20.57', '39013'))
+```
+
+The order of the format arguments is user , password, ip address or host name, port.
+
+
+2. In the "Declare a Mapping" section of the [tutorial](http://docs.sqlalchemy.org/en/latest/orm/tutorial.html) you will need to add a line defining the `__table_args__` to the User class.
+
+```
+from sqlalchemy import Column, Integer, String
+class User(Base):
+    __tablename__ = 'users'
+    #This line was added for HANA express
+    __table_args__ = {'hana_table_type': 'COLUMN'}        
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    fullname = Column(String)
+    password = Column(String)
+
+    def __repr__(self):
+    return "<User(name='%s', fullname='%s', password='%s')>" % (self.name, self.fullname, self.password)
+
+```
+
+## Next Steps
+ - [View similar How-Tos](http://www.sap.com/developer/tutorials.html) or [View all How-Tos](http://www.sap.com/developer/tutorials.html)
+ - [Complete the Django tutorials](https://docs.djangoproject.com/en/1.10/intro/tutorial01/)

--- a/tutorials/2017/03/hxe-install-git/hxe-install-git.md
+++ b/tutorials/2017/03/hxe-install-git/hxe-install-git.md
@@ -1,0 +1,92 @@
+---
+title: How to install and setup git on HANA, express edition.
+description: A How-To that shows how to install and setup the git source code management system on a HANA, express edition virtual machine.
+tags: [  tutorial>beginner, products>sap-hana, products>sap-hana\,-express-edition, tutorial>how-to ]
+---
+## Prerequisites  
+ - Proficiency: beginner
+ - Setup: `HANA, express edition` must be running.
+
+## Next Steps
+ - Complete other tutorials.
+
+## How-To Details
+The HANA, express edition virtual machine uses SuSE Linux Enterprise Server (SLES) 12.1 as the guest operating system. The HANA, express edition release of SLES includes the Zypper package manager. This tutorial shows how to use the Zypper package manager to download packages needed for setting up a `git` repository. At the end of this tutorial, your HANA, express edition virtual machine should be configured so you can clone and use `git` repositories on your HANA, express edition virtual machine.
+
+### Time to Complete
+**20 Min**.
+
+---
+
+## Setting Up Proxies
+
+1. If you are inside a firewall, you may need to configure HANA, express edition virtual machine proxies to be able to reach the internet. If you are not inside a firewall or you have already set up proxies on your virtual machine, skip ahead to `Setting Up Repositories`.
+
+2. Open up the SuSE configuration tool yast. Yast must be run as the root user.
+
+    `sudo yast`
+
+    This will open up the Yast Control Center.
+
+3. Select `Network Services` in the left hand pane using the arrow keys. This will list all the `Network Services` in the right hand pane.
+
+4. Tab over to the right hand pane.
+
+5. Navigate to the `Proxy` service and hit the Enter key to select it. This will open the `Proxy Configuration` pane.
+
+6. Select `Enable Proxy`.
+
+7. Under `HTTP Proxy URL` enter your http proxy including the port number if necessary. For example, `http://myproxy.mydomain.com:8080`. Enter the appropriate values for the other protocols. You may want to select `Use the Same Proxy for All Protocols` if you use the same proxy for all protocols. Be sure that you your `No Proxy Domains` includes `localhost,127.0.0.1`.
+
+8. Press `F10` key to save your changes.
+
+9. Press `F9` to exit yast.
+
+10. Exit the shell to make sure that your changes are picked up by the current shell.
+
+## Setting Up Software Repositories and Installing Git
+
+The HANA, express edition SuSE Linux Enterprise operating system includes the `ZYpp` system management library (`libzypp`) for managing software packages and the `zypper` command line tool for interfacing with `libzypp`. `Libzypp` stores packages in software repositories. The following instructions show how to configure the repositories needed by `libzypp` to install `git`. `Git` requires some packages from the perl repository on the `download.opensuse.org` site and several packages from the Source Code Management `scm` repository.
+
+1. Add the Perl repository, and name it `PerlRepository`:
+
+    `sudo zypper addrepo http://download.opensuse.org/repositories/devel:/languages:/perl/SLE_12_SP2/ PerlRepository`
+
+    When prompted to trust the key to the `PerlRepository`, you can choose to trust it temporarily or always depending on your security requirements.
+
+2. Add the Source Code Management repository and name it `SCMRepository`:
+
+    `sudo zypper addrepo http://download.opensuse.org/repositories/devel:/tools:/scm/SLE_12_SP2/ SCMRepository`
+
+    When prompted to trust the key to the `SCMRepository`, you can choose to trust it temporarily or always depending on your security requirements.
+
+3. Install `git` using the `zypper` install command:
+
+    `sudo zypper install git`
+
+     When prompted to continue with package installation, enter 'y'. `Git` and all its dependent packages will be installed.
+
+## Verifying the Git Installation
+
+Verify your `git` installation by cloning a git repository to your HANA, express edition virtual machine. You can do this using any `git` repository to which you have access. For this example, you will clone the `PyHDB` repository from github.com. Feel free to clone a different repository.
+
+1. Make a directory to store your `git` repositories:
+
+    `mkdir mygitprojects`
+
+2. Navigate to `mygitprojects`:
+
+    `cd mygitprojects`
+
+3. Clone the repository:
+
+    `git clone https://github.com/SAP/PyHDB.git`
+
+    You will see the message "Cloning into 'PyHDB'..."" followed by information on the number of repository objects being cloned. When the cloning is complete, you will see a line such as "Resolving deltas: 100% (738/738), done." ### Note: the number of deltas may vary depending on the release version of `PyHDB`.
+
+    When the clone completes you will be ready to use git for source code management on your HANA, express edition virtual machine
+
+
+## Next Steps
+ - [View similar How-Tos](http://www.sap.com/developer/tutorials.html) or [View all How-Tos](http://www.sap.com/developer/tutorials.html)
+ - [Complete the Django tutorials](https://docs.djangoproject.com/en/1.10/intro/tutorial01/)


### PR DESCRIPTION
I updated a comment about how to download the client drivers. This affected three How-To-Tutorials created in 2016/08.
I added three How-To Tutorials in 2017 on python and django and hxe, python and sql alchemy and hxe, and hxe and git.